### PR TITLE
Suppress false positive warnings from security scan

### DIFF
--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
@@ -173,7 +173,8 @@ public final class BitwardenCLIManager {
      *
      * @return {@code true} on success, {@code false} on failure.
      */
-    // Jenkins Security Scan checks methods matching the Stapler web method naming scheme (e.g. doWhatever), but this method is not for Stapler.
+    // Jenkins Security Scan checks methods matching the Stapler web method naming scheme (e.g. doWhatever), but this
+    // method is not for Stapler.
     // lgtm[jenkins/no-permission-check]
     // lgtm[jenkins/csrf]
     public boolean downloadLatestExecutable() {


### PR DESCRIPTION
Jenkins Security Scan checks methods matching the Stapler web method naming scheme (e.g. `doWhatever`), resulting in `BitwardenCLIManager#downloadLatestExecutable` getting falsely marked with security warnings meant for Stapler-related methods.

This PR suppresses warnings for those false positives:

- https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/security/code-scanning/1
- https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/security/code-scanning/2

### Testing done

This change requires no testing as it only changes 3 lines, all of which are comments.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed