### PR TITLE
Fixed Stapler-related false positive suppressions for security scan

### DIFF
--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLIManager.java
@@ -176,7 +176,7 @@ public final class BitwardenCLIManager {
     // Jenkins Security Scan checks methods matching the Stapler web method naming scheme (e.g. doWhatever).
     // This method matches that naming convention but is not meant to be dispatched by Stapler.
     // This annotation resolves those false positives in Jenkins Security Scan.
-    @SuppressWarnings({"lgtm[jenkins/csrf]", "lgtm[jenkins/no-permission-check]"})
+    // lgtm[jenkins/csrf, jenkins/no-permission-check]
     public boolean downloadLatestExecutable() {
         synchronized (provisionLock) {
             LOGGER.info("Downloading and provisioning the latest Bitwarden CLI executable...");


### PR DESCRIPTION
Fixed `BitwardenCLIManager#downloadLatestExecutable` security scan suppressions approach introduced in #3, which only resolved one of the warnings because the suppressions were on two different lines.

Addresses these security scan issues:

- https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/security/code-scanning/1
- https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/security/code-scanning/2

### Testing done

- Automated test coverage passed
- Ran with mvn hpi:run after cleaning the work directory, and clicked the `Download Latest` button in the Bitwarden configuration section and observed the executable successfully downloaded: 
  <img width="1038" height="597" alt="image" src="https://github.com/user-attachments/assets/cf29c606-68ba-4c22-8b29-ab730bea1af8" />
  <img width="367" height="82" alt="image" src="https://github.com/user-attachments/assets/c0d4c0a8-bda3-40b9-aade-e8af1f61e4ef" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed