### PR TITLE
fix: ensure clean Bitwarden CLI environment during re-authentication

### DIFF
--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
@@ -50,6 +50,25 @@ public final class BitwardenCLI {
     }
 
     /**
+     * Clears the Bitwarden CLI application data by deleting data.json.
+     * Ensures the CLI always has a clean working state
+     * to mitigate potential corruption caused by updating the CLI and/or using newer CLI versions.
+     * See <a href="https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/issues/18">Issue #18</a> for more information.
+     */
+    public static void clearBitwardenAppData() {
+        Path dataJsonPath = getBitwardenDataDir().toPath().resolve("data.json");
+        try {
+            if (Files.deleteIfExists(dataJsonPath))
+                LOGGER.info(
+                        "Bitwarden CLI application data file (data.json) was deleted successfully to ensure a clean state.");
+            else LOGGER.fine("No existing Bitwarden CLI application data found, skipping deletion.");
+        } catch (IOException e) {
+            LOGGER.warning(
+                    "Failed to delete Bitwarden CLI application data at: " + dataJsonPath + ": " + e.getMessage());
+        }
+    }
+
+    /**
      * Creates a {@link ProcessBuilder} for a Bitwarden CLI command, using the managed executable.
      *
      * @param command The arguments to pass to the {@code bw} command (e.g., "login", "--apikey").
@@ -237,25 +256,6 @@ public final class BitwardenCLI {
         LOGGER.info(() -> "Configuring server URL: " + serverUrl);
         executeCommand(bitwardenCommand("config", "server", serverUrl));
         LOGGER.info("Server URL configured successfully.");
-    }
-
-    /**
-     * Clears the Bitwarden CLI application data by deleting data.json.
-     * Ensures the CLI always has a clean working state
-     * to mitigate potential corruption caused by updating the CLI and/or using newer CLI versions.
-     * See <a href="https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/issues/18">Issue #18</a> for more information.
-     */
-    public static void clearBitwardenAppData() {
-        Path dataJsonPath = getBitwardenDataDir().toPath().resolve("data.json");
-        try {
-            if (Files.deleteIfExists(dataJsonPath))
-                LOGGER.info(
-                        "Bitwarden CLI application data file (data.json) was deleted successfully to ensure a clean state.");
-            else LOGGER.fine("No existing Bitwarden CLI application data found, skipping deletion.");
-        } catch (IOException e) {
-            LOGGER.warning(
-                    "Failed to delete Bitwarden CLI application data at: " + dataJsonPath + ": " + e.getMessage());
-        }
     }
 
     /**

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -37,6 +39,15 @@ public final class BitwardenCLI {
      * A private constructor to prevent instantiation of this utility class.
      */
     private BitwardenCLI() {}
+
+    /**
+     * Gets the isolated Jenkins data directory for the Bitwarden CLI.
+     *
+     * @return The File object representing the 'bwcli' subdirectory within the plugin data directory.
+     */
+    private static File getBitwardenDataDir() {
+        return new File(PluginDirectoryProvider.getPluginDataDirectory().getAbsolutePath(), "bwcli");
+    }
 
     /**
      * Creates a {@link ProcessBuilder} for a Bitwarden CLI command, using the managed executable.
@@ -229,6 +240,25 @@ public final class BitwardenCLI {
     }
 
     /**
+     * Clears the Bitwarden CLI application data by deleting data.json.
+     * Ensures the CLI always has a clean working state
+     * to mitigate potential corruption caused by updating the CLI and/or using newer CLI versions.
+     * See <a href="https://github.com/jenkinsci/bitwarden-credentials-provider-plugin/issues/18">Issue #18</a> for more information.
+     */
+    public static void clearBitwardenAppData() {
+        Path dataJsonPath = getBitwardenDataDir().toPath().resolve("data.json");
+        try {
+            if (Files.deleteIfExists(dataJsonPath))
+                LOGGER.info(
+                        "Bitwarden CLI application data file (data.json) was deleted successfully to ensure a clean state.");
+            else LOGGER.fine("No existing Bitwarden CLI application data found, skipping deletion.");
+        } catch (IOException e) {
+            LOGGER.warning(
+                    "Failed to delete Bitwarden CLI application data at: " + dataJsonPath + ": " + e.getMessage());
+        }
+    }
+
+    /**
      * The low-level command executor. This is the only method that directly runs a process.
      * It ensures every command runs with the isolated data directory.
      *
@@ -240,8 +270,7 @@ public final class BitwardenCLI {
     private static String executeCommand(ProcessBuilder pb) throws IOException, InterruptedException {
         LOGGER.fine(() -> "Executing command: " + String.join(" ", pb.command()));
         Map<String, String> env = pb.environment();
-        File bitwardenDataDir =
-                new File(PluginDirectoryProvider.getPluginDataDirectory().getAbsolutePath(), "bwcli");
+        File bitwardenDataDir = getBitwardenDataDir();
         env.put("BITWARDENCLI_APPDATA_DIR", bitwardenDataDir.getAbsolutePath());
         pb.redirectErrorStream(true);
         Process process = pb.start();

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
@@ -143,6 +143,7 @@ public class BitwardenSessionManager {
             LOGGER.fine("Server URL not set. Using default.");
             serverUrl = "https://vault.bitwarden.com";
         }
+        BitwardenCLI.clearBitwardenAppData();
         BitwardenCLI.configServer(serverUrl);
         BitwardenCLI.login(apiKey);
         return BitwardenCLI.unlock(masterPassword);

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
@@ -139,11 +139,11 @@ public class BitwardenSessionManager {
             StandardUsernamePasswordCredentials apiKey, StringCredentials masterPassword, String serverUrl)
             throws IOException, InterruptedException {
         BitwardenCLI.logout();
+        BitwardenCLI.clearBitwardenAppData();
         if (serverUrl == null || serverUrl.isEmpty()) {
             LOGGER.fine("Server URL not set. Using default.");
             serverUrl = "https://vault.bitwarden.com";
         }
-        BitwardenCLI.clearBitwardenAppData();
         BitwardenCLI.configServer(serverUrl);
         BitwardenCLI.login(apiKey);
         return BitwardenCLI.unlock(masterPassword);

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
@@ -631,4 +631,40 @@ class BitwardenCLITest {
             verifyExecuteCommandInternals();
         }
     }
+
+    @Nested
+    @DisplayName("clearBitwardenAppData()")
+    class ClearBitwardenAppData {
+        @Test
+        @DisplayName("should delete data.json if it exists")
+        void shouldDeleteDataJsonIfExists() throws IOException {
+            // GIVEN: Manually create the file in our mocked plugin data directory
+            File bwCliDir = new File(PluginDirectoryProvider.getPluginDataDirectory(), "bwcli");
+            if (!bwCliDir.exists()) bwCliDir.mkdirs();
+
+            File dataJson = new File(bwCliDir, "data.json");
+            dataJson.createNewFile();
+            assertTrue(dataJson.exists(), "Setup failed: data.json should exist before test");
+
+            // WHEN
+            BitwardenCLI.clearBitwardenAppData();
+
+            // THEN
+            assertFalse(dataJson.exists(), "data.json should have been deleted by clearBitwardenAppData");
+        }
+
+        @Test
+        @DisplayName("should not throw error if data.json does not exist")
+        void shouldNotThrowIfFileMissing() {
+            // GIVEN: Ensure the file does NOT exist
+            File bwCliDir = new File(PluginDirectoryProvider.getPluginDataDirectory(), "bwcli");
+            File dataJson = new File(bwCliDir, "data.json");
+            if (dataJson.exists()) dataJson.delete();
+
+            // WHEN & THEN
+            assertDoesNotThrow(
+                    BitwardenCLI::clearBitwardenAppData,
+                    "Method should handle missing files gracefully without throwing exceptions");
+        }
+    }
 }

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -665,6 +666,26 @@ class BitwardenCLITest {
             assertDoesNotThrow(
                     BitwardenCLI::clearBitwardenAppData,
                     "Method should handle missing files gracefully without throwing exceptions");
+        }
+
+        @Test
+        @DisplayName("should log warning and handle IOException gracefully when deletion fails")
+        void shouldHandleIOExceptionGracefully() {
+            // GIVEN: We mock the static Files class to throw an error when deletion is attempted
+            try (MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
+                mockedFiles
+                        .when(() -> Files.deleteIfExists(any(Path.class)))
+                        .thenThrow(new IOException("Simulated filesystem error (e.g., file locked)"));
+
+                // WHEN & THEN
+                // We verify that the method catches the exception and does not throw it
+                assertDoesNotThrow(
+                        BitwardenCLI::clearBitwardenAppData,
+                        "Method should catch IOException and log a warning instead of crashing");
+
+                // Ensure the code actually attempted the deletion
+                mockedFiles.verify(() -> Files.deleteIfExists(any(Path.class)), times(1));
+            }
         }
     }
 }

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenSessionManagerTest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenSessionManagerTest.java
@@ -152,7 +152,7 @@ class BitwardenSessionManagerTest {
         }
 
         @Test
-        @DisplayName("should create new token using default server URL when config is null or empty")
+        @DisplayName("should clear app data and create new token using default server URL")
         void shouldCreateNewTokenWithDefaultServerUrl() throws Exception {
             // GIVEN
             setupValidCredentials(null);
@@ -166,6 +166,8 @@ class BitwardenSessionManagerTest {
 
             // THEN
             assertEquals(newToken, resultToken);
+            mockedCli.verify(BitwardenCLI::logout, times(1));
+            mockedCli.verify(BitwardenCLI::clearBitwardenAppData, times(1));
             mockedCli.verify(() -> BitwardenCLI.configServer("https://vault.bitwarden.com"), times(1));
             mockedCli.verify(() -> BitwardenCLI.login(any(StandardUsernamePasswordCredentials.class)), times(1));
         }


### PR DESCRIPTION
Automatically delete Bitwarden CLI app data (`data.json`) before authentication to ensure a clean working state. This bypasses `Logout required` errors caused by corrupted local storage after CLI updates or when using newer versions of Bitwarden CLI.

Closes #18 and effectively mitigates [upstream Bitwarden CLI Issue #10109](https://github.com/bitwarden/clients/issues/10109)

### Testing done

- Created new unit tests to test app data deletion functionality
- Verified functionality manually via `mvn hpi:run` and confirmed it mitigates the Bitwarden CLI configuration error
- Installed [incremental release](https://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/bitwarden-credentials-provider/253.v3f1fc37dc3a_a_/bitwarden-credentials-provider-253.v3f1fc37dc3a_a_.hpi) on my production Jenkins instance and verified it works as expected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed