### PR TITLE
Enforce proper global flags for Bitwarden CLI commands and replace duplicate strings with named constants

### DIFF
--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
@@ -78,6 +78,8 @@ public final class BitwardenCLI {
         String executablePath = BitwardenCLIManager.getInstance().getExecutablePath();
         List<String> commandParts = new ArrayList<>();
         commandParts.add(executablePath);
+        commandParts.add("--nointeraction");
+        commandParts.add("--raw");
         commandParts.addAll(Arrays.asList(command));
         LOGGER.fine(() -> "Building Bitwarden command: " + String.join(" ", commandParts));
         return new ProcessBuilder(commandParts);
@@ -154,7 +156,7 @@ public final class BitwardenCLI {
      */
     public static Secret unlock(StringCredentials masterPassword) throws IOException, InterruptedException {
         LOGGER.info("Unlocking vault.");
-        ProcessBuilder pb = bitwardenCommand("unlock", "--raw", "--passwordenv", "BITWARDEN_MASTER_PASSWORD");
+        ProcessBuilder pb = bitwardenCommand("unlock", "--passwordenv", "BITWARDEN_MASTER_PASSWORD");
         Map<String, String> env = pb.environment();
         env.put("BITWARDEN_MASTER_PASSWORD", masterPassword.getSecret().getPlainText());
         try {

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
@@ -34,6 +34,7 @@ public final class BitwardenCLI {
 
     private static final Logger LOGGER = Logger.getLogger(BitwardenCLI.class.getName());
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String KEY_BW_SESSION = "BW_SESSION";
 
     /**
      * A private constructor to prevent instantiation of this utility class.
@@ -117,7 +118,7 @@ public final class BitwardenCLI {
             executeCommand(pb);
             LOGGER.info("Login successful.");
         } catch (IOException e) {
-            if (e.getMessage().contains("FetchError")) {
+            if (e.getMessage().contains(BitwardenConnectionException.IDENTIFIER)) {
                 throw new BitwardenConnectionException(Messages.exception_connectionError(), e);
             } else if (e.getMessage().contains("Username or password is incorrect")
                     || e.getMessage().contains("Invalid API Key")
@@ -162,7 +163,7 @@ public final class BitwardenCLI {
         try {
             return Secret.fromString(executeCommand(pb));
         } catch (IOException e) {
-            if (e.getMessage().contains("FetchError")) {
+            if (e.getMessage().contains(BitwardenConnectionException.IDENTIFIER)) {
                 throw new BitwardenConnectionException(Messages.exception_connectionError(), e);
             } else if (e.getMessage().contains("Invalid master password")) {
                 throw new BitwardenAuthenticationException(Messages.exception_unlockError(), e);
@@ -182,12 +183,12 @@ public final class BitwardenCLI {
     public static void sync(Secret sessionToken) throws IOException, InterruptedException {
         LOGGER.info("Syncing vault.");
         ProcessBuilder pb = bitwardenCommand("sync");
-        pb.environment().put("BW_SESSION", Secret.toString(sessionToken));
+        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
         try {
             executeCommand(pb);
             LOGGER.info("Vault sync complete.");
         } catch (IOException e) {
-            if (e.getMessage().contains("FetchError")) {
+            if (e.getMessage().contains(BitwardenConnectionException.IDENTIFIER)) {
                 throw new BitwardenConnectionException(Messages.exception_syncError(), e);
             }
             throw e; // Re-throw the original generic exception if it's not a known type
@@ -205,7 +206,7 @@ public final class BitwardenCLI {
     public static BitwardenStatus status(Secret sessionToken) throws IOException, InterruptedException {
         LOGGER.fine("Fetching CLI status.");
         ProcessBuilder pb = bitwardenCommand("status");
-        pb.environment().put("BW_SESSION", Secret.toString(sessionToken));
+        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
         String json = executeCommand(pb);
         LOGGER.fine(() -> "CLI status fetched successfully. JSON: " + json);
         return OBJECT_MAPPER.readValue(json, BitwardenStatus.class);
@@ -222,7 +223,7 @@ public final class BitwardenCLI {
     public static List<BitwardenItemMetadata> listItemsMetadata(Secret sessionToken)
             throws IOException, InterruptedException {
         ProcessBuilder pb = bitwardenCommand("list", "items");
-        pb.environment().put("BW_SESSION", Secret.toString(sessionToken));
+        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
         String json = executeCommand(pb);
         List<BitwardenItemMetadata> metadataList = OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
         LOGGER.info(() -> "Successfully deserialized metadata for " + metadataList.size() + " items.");
@@ -241,7 +242,7 @@ public final class BitwardenCLI {
     public static BitwardenItem getItem(Secret sessionToken, String itemId) throws IOException, InterruptedException {
         LOGGER.fine(() -> "Fetching single vault item with ID: " + itemId);
         ProcessBuilder pb = bitwardenCommand("get", "item", itemId);
-        pb.environment().put("BW_SESSION", Secret.toString(sessionToken));
+        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
         String json = executeCommand(pb);
         LOGGER.fine(() -> "Single vault item " + itemId + " fetched successfully.");
         return OBJECT_MAPPER.readValue(json, BitwardenItem.class);

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenConnectionException.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenConnectionException.java
@@ -7,6 +7,9 @@ import java.io.IOException;
  * network-related issue, such as a DNS failure or an inability to connect to the server.
  */
 public class BitwardenConnectionException extends IOException {
+
+    public static final String IDENTIFIER = "FetchError";
+
     /**
      * Constructs a new BitwardenConnectionException.
      *

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
@@ -17,6 +17,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import jenkins.security.ConfidentialStore;
@@ -42,6 +44,8 @@ import org.mockito.MockitoAnnotations;
 class BitwardenCLITest {
 
     private static final String FAKE_EXECUTABLE_PATH = "/fake/path/bw";
+    private static final String NO_INTERACTION_FLAG = "--nointeraction";
+    private static final String RAW_FLAG = "--raw";
     // Mocks for static dependencies
     private static MockedStatic<BitwardenCLIManager> mockedCliManager;
     private static MockedStatic<PluginDirectoryProvider> mockedPluginDir;
@@ -160,6 +164,16 @@ class BitwardenCLITest {
     }
 
     /**
+     * Helper method to generate the expected command list, automatically prepending
+     * the executable and global flags.
+     */
+    private List<String> expectedCommand(String... commandArgs) {
+        List<String> expectedCommand = new ArrayList<>(List.of(FAKE_EXECUTABLE_PATH, NO_INTERACTION_FLAG, RAW_FLAG));
+        expectedCommand.addAll(Arrays.asList(commandArgs));
+        return expectedCommand;
+    }
+
+    /**
      * Helper method to verify the common side-effects of `executeCommand`.
      * This ensures our tests are as thorough as the production code.
      */
@@ -186,7 +200,7 @@ class BitwardenCLITest {
             // THEN
             assertEquals(expectedVersion, actualVersion);
             assertNotNull(capturedCommand, "Command list was not captured from constructor");
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "--version"), capturedCommand);
+            assertEquals(expectedCommand("--version"), capturedCommand);
             verify(processBuilderMock).start();
             verifyExecuteCommandInternals();
         }
@@ -245,7 +259,7 @@ class BitwardenCLITest {
             BitwardenCLI.login(apiKeyCredentialsMock);
 
             // THEN
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "login", "--apikey"), capturedCommand);
+            assertEquals(expectedCommand("login", "--apikey"), capturedCommand);
             verify(environmentMapMock).put("BW_CLIENTID", "test-client-id");
             verify(environmentMapMock).put("BW_CLIENTSECRET", "test-client-secret");
             verify(processBuilderMock).start();
@@ -306,7 +320,7 @@ class BitwardenCLITest {
             BitwardenCLI.logout();
 
             // THEN
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "logout"), capturedCommand);
+            assertEquals(expectedCommand("logout"), capturedCommand);
             verify(processBuilderMock).start();
             verifyExecuteCommandInternals();
         }
@@ -320,7 +334,7 @@ class BitwardenCLITest {
             // WHEN & THEN
             // Verify that no exception is thrown, as the method is designed to ignore errors
             assertDoesNotThrow(BitwardenCLI::logout);
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "logout"), capturedCommand);
+            assertEquals(expectedCommand("logout"), capturedCommand);
             verifyExecuteCommandInternals();
         }
     }
@@ -347,9 +361,7 @@ class BitwardenCLITest {
             Secret resultToken = BitwardenCLI.unlock(masterPasswordCredentialsMock);
 
             // THEN
-            assertEquals(
-                    List.of(FAKE_EXECUTABLE_PATH, "unlock", "--raw", "--passwordenv", "BITWARDEN_MASTER_PASSWORD"),
-                    capturedCommand);
+            assertEquals(expectedCommand("unlock", "--passwordenv", "BITWARDEN_MASTER_PASSWORD"), capturedCommand);
             verify(environmentMapMock).put("BITWARDEN_MASTER_PASSWORD", "test-master-password");
             verify(processBuilderMock).start();
             assertNotNull(resultToken);
@@ -421,7 +433,7 @@ class BitwardenCLITest {
             BitwardenCLI.sync(mockSessionToken);
 
             // THEN
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "sync"), capturedCommand);
+            assertEquals(expectedCommand("sync"), capturedCommand);
             verify(environmentMapMock).put("BW_SESSION", "test-session-token");
             verify(processBuilderMock).start();
             verifyExecuteCommandInternals();
@@ -478,7 +490,7 @@ class BitwardenCLITest {
             BitwardenStatus status = BitwardenCLI.status(mockSessionToken);
 
             // THEN
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "status"), capturedCommand);
+            assertEquals(expectedCommand("status"), capturedCommand);
             verify(environmentMapMock).put("BW_SESSION", "test-session-token");
             verify(processBuilderMock).start();
             assertNotNull(status);
@@ -526,7 +538,7 @@ class BitwardenCLITest {
             List<BitwardenItemMetadata> metadataList = BitwardenCLI.listItemsMetadata(mockSessionToken);
 
             // THEN
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "list", "items"), capturedCommand);
+            assertEquals(expectedCommand("list", "items"), capturedCommand);
             verify(environmentMapMock).put("BW_SESSION", "test-session-token");
             verify(processBuilderMock).start();
             assertNotNull(metadataList);
@@ -578,7 +590,7 @@ class BitwardenCLITest {
             BitwardenItem item = BitwardenCLI.getItem(mockSessionToken, ITEM_ID);
 
             // THEN
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "get", "item", ITEM_ID), capturedCommand);
+            assertEquals(expectedCommand("get", "item", ITEM_ID), capturedCommand);
             verify(environmentMapMock).put("BW_SESSION", "test-session-token");
             verify(processBuilderMock).start();
             assertNotNull(item);
@@ -615,7 +627,7 @@ class BitwardenCLITest {
             BitwardenCLI.configServer(serverUrl);
 
             // THEN
-            assertEquals(List.of(FAKE_EXECUTABLE_PATH, "config", "server", serverUrl), capturedCommand);
+            assertEquals(expectedCommand("config", "server", serverUrl), capturedCommand);
             verify(processBuilderMock).start();
             verifyExecuteCommandInternals();
         }


### PR DESCRIPTION
- Enforce the `--nointeraction` and `--raw` flags globally for Bitwarden CLI commands.
  - More information about these flags can be found in the official [Password Manager CLI Documentation](https://bitwarden.com/help/cli/#global-options).
- Replace various duplicated string literals with named constants

Fixes #23

### Testing done

Tested all features manually via `mvn hpi:run` and updated automated tests accordingly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed