### PR TITLE
fix: improve Bitwarden CLI execution reliability, output handling and thread safety

### DIFF
--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
@@ -285,16 +285,13 @@ public final class BitwardenCLI {
                 .start();
 
         int exitCode = process.joinWithTimeout(5, TimeUnit.MINUTES, TaskListener.NULL);
-
-        if (process.isAlive()) {
-            process.kill();
-            throw new IOException("Bitwarden CLI command timed out after 5 minutes: " + args);
-        }
-
         String output = stdout.toString(StandardCharsets.UTF_8).trim();
         String errors = stderr.toString(StandardCharsets.UTF_8).trim();
 
-        if (exitCode != 0) {
+        if (process.isAlive()) {
+            process.kill();
+            throw new IOException("Bitwarden CLI command timed out after 5 minutes: " + args + ". Stderr: " + errors);
+        } else if (exitCode != 0) {
             throw new IOException("Command failed with exit code " + exitCode + ". Stderr: " + errors);
         } else if (!errors.isEmpty()) {
             LOGGER.fine(() -> "CLI Exit code is 0, but stderr is not empty: " + errors);

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenCLI.java
@@ -8,27 +8,29 @@ import com.mwdle.bitwarden.PluginDirectoryProvider;
 import com.mwdle.bitwarden.model.BitwardenItem;
 import com.mwdle.bitwarden.model.BitwardenItemMetadata;
 import com.mwdle.bitwarden.model.BitwardenStatus;
+import hudson.Launcher;
+import hudson.Proc;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
 import hudson.util.Secret;
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 /**
  * A utility class for executing Bitwarden CLI commands.
  * <p>
- * This class contains only static methods and holds no state. It is a thin wrapper around the
- * {@code bw} executable, responsible for the low-level logic of constructing and running
- * {@link ProcessBuilder} commands and interpreting their results.
+ * This class contains only static methods and holds no state. It is a thin wrapper around the {@code bw} executable,
+ * responsible for the low-level logic of constructing and running commands and interpreting their results.
  */
 public final class BitwardenCLI {
 
@@ -70,20 +72,19 @@ public final class BitwardenCLI {
     }
 
     /**
-     * Creates a {@link ProcessBuilder} for a Bitwarden CLI command, using the managed executable.
+     * Creates a {@link ArgumentListBuilder} for a Bitwarden CLI command, using the managed executable.
      *
-     * @param command The arguments to pass to the {@code bw} command (e.g., "login", "--apikey").
-     * @return A configured ProcessBuilder instance.
+     * @param args The arguments to pass to the {@code bw} command (e.g., "login", "--apikey").
+     * @return A configured ArgumentListBuilder instance.
      */
-    private static ProcessBuilder bitwardenCommand(String... command) {
+    private static ArgumentListBuilder bitwardenCommand(String... args) {
         String executablePath = BitwardenCLIManager.getInstance().getExecutablePath();
-        List<String> commandParts = new ArrayList<>();
-        commandParts.add(executablePath);
-        commandParts.add("--nointeraction");
-        commandParts.add("--raw");
-        commandParts.addAll(Arrays.asList(command));
-        LOGGER.fine(() -> "Building Bitwarden command: " + String.join(" ", commandParts));
-        return new ProcessBuilder(commandParts);
+        ArgumentListBuilder command = new ArgumentListBuilder();
+        command.add(executablePath);
+        command.add("--nointeraction");
+        command.add("--raw");
+        command.add(args);
+        return command;
     }
 
     /**
@@ -95,8 +96,7 @@ public final class BitwardenCLI {
      */
     public static String version() throws IOException, InterruptedException {
         LOGGER.info("Fetching Bitwarden CLI version");
-        ProcessBuilder pb = bitwardenCommand("--version");
-        return executeCommand(pb);
+        return executeCommand(bitwardenCommand("--version"), Map.of());
     }
 
     /**
@@ -110,12 +110,11 @@ public final class BitwardenCLI {
      */
     public static void login(StandardUsernamePasswordCredentials apiKey) throws IOException, InterruptedException {
         LOGGER.info("Logging in with API key credentials.");
-        ProcessBuilder pb = bitwardenCommand("login", "--apikey");
-        Map<String, String> env = pb.environment();
-        env.put("BW_CLIENTID", apiKey.getUsername());
-        env.put("BW_CLIENTSECRET", apiKey.getPassword().getPlainText());
+        Map<String, String> env = Map.of(
+                "BW_CLIENTID", apiKey.getUsername(),
+                "BW_CLIENTSECRET", apiKey.getPassword().getPlainText());
         try {
-            executeCommand(pb);
+            executeCommand(bitwardenCommand("login", "--apikey"), env);
             LOGGER.info("Login successful.");
         } catch (IOException e) {
             if (e.getMessage().contains(BitwardenConnectionException.IDENTIFIER)) {
@@ -136,12 +135,12 @@ public final class BitwardenCLI {
      */
     public static void logout() throws InterruptedException {
         LOGGER.info("Logging out...");
-        ProcessBuilder pb = bitwardenCommand("logout");
         try {
-            executeCommand(pb);
+            executeCommand(bitwardenCommand("logout"), Map.of());
             LOGGER.info("Logout successful.");
         } catch (IOException ignored) {
-            // If logout fails, we are likely already logged out, so we can safely ignore it.
+            // If logout fails, we are likely already logged out. Regardless, the plugin resets the CLI data directory
+            // on reauthentication.
         }
     }
 
@@ -157,11 +156,11 @@ public final class BitwardenCLI {
      */
     public static Secret unlock(StringCredentials masterPassword) throws IOException, InterruptedException {
         LOGGER.info("Unlocking vault.");
-        ProcessBuilder pb = bitwardenCommand("unlock", "--passwordenv", "BITWARDEN_MASTER_PASSWORD");
-        Map<String, String> env = pb.environment();
-        env.put("BITWARDEN_MASTER_PASSWORD", masterPassword.getSecret().getPlainText());
+        Map<String, String> env =
+                Map.of("BITWARDEN_MASTER_PASSWORD", masterPassword.getSecret().getPlainText());
         try {
-            return Secret.fromString(executeCommand(pb));
+            return Secret.fromString(
+                    executeCommand(bitwardenCommand("unlock", "--passwordenv", "BITWARDEN_MASTER_PASSWORD"), env));
         } catch (IOException e) {
             if (e.getMessage().contains(BitwardenConnectionException.IDENTIFIER)) {
                 throw new BitwardenConnectionException(Messages.exception_connectionError(), e);
@@ -182,10 +181,9 @@ public final class BitwardenCLI {
      */
     public static void sync(Secret sessionToken) throws IOException, InterruptedException {
         LOGGER.info("Syncing vault.");
-        ProcessBuilder pb = bitwardenCommand("sync");
-        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
+        Map<String, String> env = Map.of(KEY_BW_SESSION, Secret.toString(sessionToken));
         try {
-            executeCommand(pb);
+            executeCommand(bitwardenCommand("sync"), env);
             LOGGER.info("Vault sync complete.");
         } catch (IOException e) {
             if (e.getMessage().contains(BitwardenConnectionException.IDENTIFIER)) {
@@ -205,9 +203,8 @@ public final class BitwardenCLI {
      */
     public static BitwardenStatus status(Secret sessionToken) throws IOException, InterruptedException {
         LOGGER.fine("Fetching CLI status.");
-        ProcessBuilder pb = bitwardenCommand("status");
-        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
-        String json = executeCommand(pb);
+        Map<String, String> env = Map.of(KEY_BW_SESSION, Secret.toString(sessionToken));
+        String json = executeCommand(bitwardenCommand("status"), env);
         LOGGER.fine(() -> "CLI status fetched successfully. JSON: " + json);
         return OBJECT_MAPPER.readValue(json, BitwardenStatus.class);
     }
@@ -222,9 +219,8 @@ public final class BitwardenCLI {
      */
     public static List<BitwardenItemMetadata> listItemsMetadata(Secret sessionToken)
             throws IOException, InterruptedException {
-        ProcessBuilder pb = bitwardenCommand("list", "items");
-        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
-        String json = executeCommand(pb);
+        Map<String, String> env = Map.of(KEY_BW_SESSION, Secret.toString(sessionToken));
+        String json = executeCommand(bitwardenCommand("list", "items"), env);
         List<BitwardenItemMetadata> metadataList = OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
         LOGGER.info(() -> "Successfully deserialized metadata for " + metadataList.size() + " items.");
         return metadataList;
@@ -241,9 +237,8 @@ public final class BitwardenCLI {
      */
     public static BitwardenItem getItem(Secret sessionToken, String itemId) throws IOException, InterruptedException {
         LOGGER.fine(() -> "Fetching single vault item with ID: " + itemId);
-        ProcessBuilder pb = bitwardenCommand("get", "item", itemId);
-        pb.environment().put(KEY_BW_SESSION, Secret.toString(sessionToken));
-        String json = executeCommand(pb);
+        Map<String, String> env = Map.of(KEY_BW_SESSION, Secret.toString(sessionToken));
+        String json = executeCommand(bitwardenCommand("get", "item", itemId), env);
         LOGGER.fine(() -> "Single vault item " + itemId + " fetched successfully.");
         return OBJECT_MAPPER.readValue(json, BitwardenItem.class);
     }
@@ -257,39 +252,54 @@ public final class BitwardenCLI {
      */
     public static void configServer(String serverUrl) throws IOException, InterruptedException {
         LOGGER.info(() -> "Configuring server URL: " + serverUrl);
-        executeCommand(bitwardenCommand("config", "server", serverUrl));
+        executeCommand(bitwardenCommand("config", "server", serverUrl), Map.of());
         LOGGER.info("Server URL configured successfully.");
     }
 
     /**
-     * The low-level command executor. This is the only method that directly runs a process.
+     * The low-level command executor. This is the only method that runs the Bitwarden CLI.
      * It ensures every command runs with the isolated data directory.
      *
-     * @param pb The configured ProcessBuilder for the command to run.
+     * @param args The configured ArgumentListBuilder for the command to run.
+     * @param environment Map of environment variables. Cannot be null.
      * @return The standard output of the command as a trimmed String.
-     * @throws IOException          if the command returns a non-zero exit code.
+     * @throws IOException          if the command returns a non-zero exit code or fails to start.
      * @throws InterruptedException if the thread is interrupted.
      */
-    private static String executeCommand(ProcessBuilder pb) throws IOException, InterruptedException {
-        LOGGER.fine(() -> "Executing command: " + String.join(" ", pb.command()));
-        Map<String, String> env = pb.environment();
-        File bitwardenDataDir = getBitwardenDataDir();
-        env.put("BITWARDENCLI_APPDATA_DIR", bitwardenDataDir.getAbsolutePath());
-        pb.redirectErrorStream(true);
-        Process process = pb.start();
-        StringBuilder output = new StringBuilder();
-        try (BufferedReader reader =
-                new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                output.append(line);
-            }
+    private static String executeCommand(ArgumentListBuilder args, Map<String, String> environment)
+            throws IOException, InterruptedException {
+        LOGGER.fine(() -> "Executing command: " + args);
+
+        Map<String, String> env = new HashMap<>(environment);
+        env.put("BITWARDENCLI_APPDATA_DIR", getBitwardenDataDir().getAbsolutePath());
+
+        Launcher launcher = new Launcher.LocalLauncher(TaskListener.NULL);
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+        Proc process = launcher.launch()
+                .cmds(args)
+                .envs(env)
+                .stdout(stdout)
+                .stderr(stderr)
+                .start();
+
+        int exitCode = process.joinWithTimeout(5, TimeUnit.MINUTES, TaskListener.NULL);
+
+        if (process.isAlive()) {
+            process.kill();
+            throw new IOException("Bitwarden CLI command timed out after 5 minutes: " + args);
         }
-        int exitCode = process.waitFor();
+
+        String output = stdout.toString(StandardCharsets.UTF_8).trim();
+        String errors = stderr.toString(StandardCharsets.UTF_8).trim();
+
         if (exitCode != 0) {
-            // Only throw the raw exception. The calling method is responsible for interpreting it.
-            throw new IOException("Command failed with exit code " + exitCode + ". Output: " + output);
+            throw new IOException("Command failed with exit code " + exitCode + ". Stderr: " + errors);
+        } else if (!errors.isEmpty()) {
+            LOGGER.fine(() -> "CLI Exit code is 0, but stderr is not empty: " + errors);
         }
-        return output.toString().trim();
+
+        return output;
     }
 }

--- a/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
+++ b/src/main/java/com/mwdle/bitwarden/cli/BitwardenSessionManager.java
@@ -117,11 +117,14 @@ public class BitwardenSessionManager {
         try {
             BitwardenStatus response = BitwardenCLI.status(this.sessionToken);
             return response.getStatus().equals("unlocked");
+        } catch (InterruptedException e) {
+            LOGGER.warning("Thread was interrupted while checking Bitwarden session status.");
+            Thread.currentThread().interrupt();
         } catch (Exception e) {
             // If the status command fails for any reason, the token is considered invalid.
             LOGGER.warning("Failed to check Bitwarden session token status: " + e.getMessage());
-            return false;
         }
+        return false;
     }
 
     /**

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
@@ -93,7 +93,6 @@ class BitwardenCLITest {
     private int mockExitCode = 0;
 
     @BeforeEach
-    @SuppressWarnings("unchecked")
     void setUp() throws Exception {
         closeable = MockitoAnnotations.openMocks(this);
 
@@ -158,9 +157,9 @@ class BitwardenCLITest {
                 });
 
         // Mock the construction of Launcher.LocalLauncher to return our ProcStarter
-        launcherMockedConstruction = mockConstruction(Launcher.LocalLauncher.class, (mock, context) -> {
-            when(mock.launch()).thenReturn(procStarterMock);
-        });
+        launcherMockedConstruction =
+                mockConstruction(Launcher.LocalLauncher.class, (mock, context) -> when(mock.launch())
+                        .thenReturn(procStarterMock));
     }
 
     @AfterEach

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
@@ -9,11 +9,14 @@ import com.mwdle.bitwarden.PluginDirectoryProvider;
 import com.mwdle.bitwarden.model.BitwardenItem;
 import com.mwdle.bitwarden.model.BitwardenItemMetadata;
 import com.mwdle.bitwarden.model.BitwardenStatus;
+import hudson.Launcher;
+import hudson.Proc;
+import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
 import hudson.util.Secret;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import jenkins.security.ConfidentialStore;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.junit.jupiter.api.*;
@@ -37,8 +41,9 @@ import org.mockito.MockitoAnnotations;
  * <p>
  * This test suite verifies that the CLI wrapper correctly builds commands,
  * passes environment variables, and parses the output from the {@code bw}
- * executable. It mocks the {@link ProcessBuilder} and {@link Process} classes
- * to simulate various successful and failed CLI interactions.
+ * executable. It mocks the Jenkins {@link Launcher} and {@link Launcher.ProcStarter}
+ * to simulate various successful and failed CLI interactions, ensuring that
+ * stdout and stderr are handled separately.
  */
 @DisplayName("BitwardenCLI")
 class BitwardenCLITest {
@@ -46,6 +51,7 @@ class BitwardenCLITest {
     private static final String FAKE_EXECUTABLE_PATH = "/fake/path/bw";
     private static final String NO_INTERACTION_FLAG = "--nointeraction";
     private static final String RAW_FLAG = "--raw";
+
     // Mocks for static dependencies
     private static MockedStatic<BitwardenCLIManager> mockedCliManager;
     private static MockedStatic<PluginDirectoryProvider> mockedPluginDir;
@@ -55,23 +61,17 @@ class BitwardenCLITest {
 
     @TempDir
     Path tempDir;
-    // Mocks for constructed objects
-    private MockedConstruction<ProcessBuilder> processBuilderMockedConstruction;
+
+    // Mocks for Launcher infrastructure
+    private MockedConstruction<Launcher.LocalLauncher> launcherMockedConstruction;
+    private Launcher.ProcStarter procStarterMock;
+
     // Mock instances
     @Mock
     private BitwardenCLIManager cliManagerMock;
 
     @Mock
-    private ProcessBuilder processBuilderMock;
-
-    @Mock
-    private Process processMock;
-
-    @Mock
     private ConfidentialStore confidentialStoreMock;
-
-    @Mock
-    private Map<String, String> environmentMapMock;
 
     @Mock
     private StandardUsernamePasswordCredentials apiKeyCredentialsMock;
@@ -80,11 +80,21 @@ class BitwardenCLITest {
     private StringCredentials masterPasswordCredentialsMock;
 
     private AutoCloseable closeable;
-    private List<String> capturedCommand; // Field to store the command
+
+    // Captured values from the Launcher fluent chain
+    private ArgumentListBuilder capturedCommand;
+    private Map<String, String> capturedEnvs;
+    private OutputStream capturedStdout;
+    private OutputStream capturedStderr;
+
+    // Mock process behavior — set by setupMockProcess()
+    private String mockStdoutContent = "";
+    private String mockStderrContent = "";
+    private int mockExitCode = 0;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    void setUp() throws InterruptedException {
+    void setUp() throws Exception {
         closeable = MockitoAnnotations.openMocks(this);
 
         // Mock static utility classes
@@ -119,25 +129,38 @@ class BitwardenCLITest {
         when(Messages.exception_unlockError()).thenReturn("Unlock error");
         when(Messages.exception_syncError()).thenReturn("Sync error");
 
-        // Mock the construction of ProcessBuilder to intercept all CLI commands
-        // This is the core of the test setup.
-        processBuilderMockedConstruction = mockConstruction(ProcessBuilder.class, (mock, context) -> {
-            // CAPTURE THE COMMAND LIST FROM THE CONSTRUCTOR
-            capturedCommand = (List<String>) context.arguments().get(0);
+        // Create the ProcStarter mock and set up the fluent chain with value capture
+        procStarterMock = mock(Launcher.ProcStarter.class);
 
-            // When a ProcessBuilder is created, stub its methods
-            when(mock.start()).thenReturn(processMock);
-            when(mock.redirectErrorStream(anyBoolean())).thenReturn(mock);
-            // Return a mockable map for the environment
-            when(mock.environment()).thenReturn(environmentMapMock);
-            // Store the mock for later verification
-            processBuilderMock = mock;
+        when(procStarterMock.cmds(any(ArgumentListBuilder.class))).thenAnswer(invocation -> {
+            capturedCommand = invocation.getArgument(0);
+            return procStarterMock;
         });
+        when(procStarterMock.envs(anyMap())).thenAnswer(invocation -> {
+            capturedEnvs = invocation.getArgument(0);
+            return procStarterMock;
+        });
+        when(procStarterMock.stdout(any(OutputStream.class))).thenAnswer(invocation -> {
+            capturedStdout = invocation.getArgument(0);
+            return procStarterMock;
+        });
+        when(procStarterMock.stderr(any(OutputStream.class))).thenAnswer(invocation -> {
+            capturedStderr = invocation.getArgument(0);
+            return procStarterMock;
+        });
+        Proc procMock = mock(Proc.class);
+        when(procStarterMock.start()).thenReturn(procMock);
+        when(procMock.joinWithTimeout(anyLong(), any(TimeUnit.class), any(TaskListener.class)))
+                .thenAnswer(invocation -> {
+                    capturedStdout.write(mockStdoutContent.getBytes(StandardCharsets.UTF_8));
+                    capturedStderr.write(mockStderrContent.getBytes(StandardCharsets.UTF_8));
+                    return mockExitCode;
+                });
 
-        // Configure the default behavior for the mock Process
-        // Tests can override this as needed
-        when(processMock.getInputStream()).thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
-        when(processMock.waitFor()).thenReturn(0);
+        // Mock the construction of Launcher.LocalLauncher to return our ProcStarter
+        launcherMockedConstruction = mockConstruction(Launcher.LocalLauncher.class, (mock, context) -> {
+            when(mock.launch()).thenReturn(procStarterMock);
+        });
     }
 
     @AfterEach
@@ -147,20 +170,33 @@ class BitwardenCLITest {
         mockedConfidentialStore.close();
         mockedSecret.close();
         mockedMessages.close();
-        processBuilderMockedConstruction.close();
+        launcherMockedConstruction.close();
         closeable.close();
     }
 
     /**
-     * Helper method to configure the mock process for a test.
+     * Helper method to configure the mock process stdout and exit code.
      *
-     * @param output   The string to be returned by the process's stdout.
-     * @param exitCode The integer exit code to be returned by process.waitFor().
+     * @param stdout   The string to be written to the process's stdout stream.
+     * @param exitCode The integer exit code to be returned by the process.
      */
-    void setupMockProcess(String output, int exitCode) throws InterruptedException {
-        InputStream inputStream = new ByteArrayInputStream(output.getBytes(StandardCharsets.UTF_8));
-        when(processMock.getInputStream()).thenReturn(inputStream);
-        when(processMock.waitFor()).thenReturn(exitCode);
+    void setupMockProcess(String stdout, int exitCode) {
+        this.mockStdoutContent = stdout;
+        this.mockStderrContent = "";
+        this.mockExitCode = exitCode;
+    }
+
+    /**
+     * Helper method to configure the mock process with separate stdout and stderr content.
+     *
+     * @param stdout   The string to be written to the process's stdout stream.
+     * @param stderr   The string to be written to the process's stderr stream.
+     * @param exitCode The integer exit code to be returned by the process.
+     */
+    void setupMockProcess(String stdout, String stderr, int exitCode) {
+        this.mockStdoutContent = stdout;
+        this.mockStderrContent = stderr;
+        this.mockExitCode = exitCode;
     }
 
     /**
@@ -174,14 +210,17 @@ class BitwardenCLITest {
     }
 
     /**
-     * Helper method to verify the common side-effects of `executeCommand`.
-     * This ensures our tests are as thorough as the production code.
+     * Helper method to verify the common side-effects of {@code executeCommand}.
+     * Asserts that the isolated data directory environment variable is set for every command.
      */
     void verifyExecuteCommandInternals() {
-        // Verify the dedicated data directory is set for *every* command
-        verify(environmentMapMock).put(eq("BITWARDENCLI_APPDATA_DIR"), endsWith(File.separator + "bwcli"));
-        // Verify error stream is redirected for *every* command
-        verify(processBuilderMock).redirectErrorStream(true);
+        assertNotNull(capturedEnvs, "Environment variables were not captured from the Launcher");
+        assertTrue(
+                capturedEnvs.containsKey("BITWARDENCLI_APPDATA_DIR"),
+                "BITWARDENCLI_APPDATA_DIR should be set for every command");
+        assertTrue(
+                capturedEnvs.get("BITWARDENCLI_APPDATA_DIR").endsWith(File.separator + "bwcli"),
+                "BITWARDENCLI_APPDATA_DIR should point to the bwcli subdirectory");
     }
 
     @Nested
@@ -199,9 +238,8 @@ class BitwardenCLITest {
 
             // THEN
             assertEquals(expectedVersion, actualVersion);
-            assertNotNull(capturedCommand, "Command list was not captured from constructor");
-            assertEquals(expectedCommand("--version"), capturedCommand);
-            verify(processBuilderMock).start();
+            assertNotNull(capturedCommand, "Command was not captured from Launcher");
+            assertEquals(expectedCommand("--version"), capturedCommand.toList());
             verifyExecuteCommandInternals();
         }
 
@@ -222,10 +260,10 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw IOException on non-zero exit code")
-        void shouldThrowIOExceptionOnFailure() throws InterruptedException {
+        void shouldThrowIOExceptionOnFailure() {
             // GIVEN
             String errorOutput = "Command not found";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             IOException exception = assertThrows(IOException.class, BitwardenCLI::version);
@@ -259,19 +297,18 @@ class BitwardenCLITest {
             BitwardenCLI.login(apiKeyCredentialsMock);
 
             // THEN
-            assertEquals(expectedCommand("login", "--apikey"), capturedCommand);
-            verify(environmentMapMock).put("BW_CLIENTID", "test-client-id");
-            verify(environmentMapMock).put("BW_CLIENTSECRET", "test-client-secret");
-            verify(processBuilderMock).start();
+            assertEquals(expectedCommand("login", "--apikey"), capturedCommand.toList());
+            assertEquals("test-client-id", capturedEnvs.get("BW_CLIENTID"));
+            assertEquals("test-client-secret", capturedEnvs.get("BW_CLIENTSECRET"));
             verifyExecuteCommandInternals();
         }
 
         @Test
         @DisplayName("should throw BitwardenConnectionException on FetchError")
-        void shouldThrowConnectionException() throws InterruptedException {
+        void shouldThrowConnectionException() {
             // GIVEN
             String errorOutput = "FetchError: request to https://... failed";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             assertThrows(BitwardenConnectionException.class, () -> BitwardenCLI.login(apiKeyCredentialsMock));
@@ -281,9 +318,9 @@ class BitwardenCLITest {
         @ParameterizedTest
         @ValueSource(strings = {"Invalid API Key", "Username or password is incorrect", "Incorrect client_secret"})
         @DisplayName("should throw BitwardenAuthenticationException for all auth errors")
-        void shouldThrowAuthenticationException(String errorOutput) throws InterruptedException {
+        void shouldThrowAuthenticationException(String errorOutput) {
             // GIVEN
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             assertThrows(BitwardenAuthenticationException.class, () -> BitwardenCLI.login(apiKeyCredentialsMock));
@@ -292,10 +329,10 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw generic IOException for other errors")
-        void shouldThrowGenericIOException() throws InterruptedException {
+        void shouldThrowGenericIOException() {
             // GIVEN
             String errorOutput = "An unexpected error occurred.";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             IOException exception = assertThrows(IOException.class, () -> BitwardenCLI.login(apiKeyCredentialsMock));
@@ -312,7 +349,7 @@ class BitwardenCLITest {
     class Logout {
         @Test
         @DisplayName("should call the logout command")
-        void shouldCallLogoutCommand() throws IOException, InterruptedException {
+        void shouldCallLogoutCommand() throws InterruptedException {
             // GIVEN
             setupMockProcess("Logout successful.", 0);
 
@@ -320,21 +357,20 @@ class BitwardenCLITest {
             BitwardenCLI.logout();
 
             // THEN
-            assertEquals(expectedCommand("logout"), capturedCommand);
-            verify(processBuilderMock).start();
+            assertEquals(expectedCommand("logout"), capturedCommand.toList());
             verifyExecuteCommandInternals();
         }
 
         @Test
         @DisplayName("should ignore IOException on failure")
-        void shouldIgnoreIOExceptionOnFailure() throws InterruptedException {
+        void shouldIgnoreIOExceptionOnFailure() {
             // GIVEN
-            setupMockProcess("You are not logged in.", 1);
+            setupMockProcess("", "You are not logged in.", 1);
 
             // WHEN & THEN
             // Verify that no exception is thrown, as the method is designed to ignore errors
             assertDoesNotThrow(BitwardenCLI::logout);
-            assertEquals(expectedCommand("logout"), capturedCommand);
+            assertEquals(expectedCommand("logout"), capturedCommand.toList());
             verifyExecuteCommandInternals();
         }
     }
@@ -361,9 +397,9 @@ class BitwardenCLITest {
             Secret resultToken = BitwardenCLI.unlock(masterPasswordCredentialsMock);
 
             // THEN
-            assertEquals(expectedCommand("unlock", "--passwordenv", "BITWARDEN_MASTER_PASSWORD"), capturedCommand);
-            verify(environmentMapMock).put("BITWARDEN_MASTER_PASSWORD", "test-master-password");
-            verify(processBuilderMock).start();
+            assertEquals(
+                    expectedCommand("unlock", "--passwordenv", "BITWARDEN_MASTER_PASSWORD"), capturedCommand.toList());
+            assertEquals("test-master-password", capturedEnvs.get("BITWARDEN_MASTER_PASSWORD"));
             assertNotNull(resultToken);
             assertEquals(sessionToken, resultToken.getPlainText());
             verifyExecuteCommandInternals();
@@ -371,10 +407,10 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw BitwardenConnectionException on FetchError")
-        void shouldThrowConnectionException() throws InterruptedException {
+        void shouldThrowConnectionException() {
             // GIVEN
             String errorOutput = "FetchError: request to https://... failed";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             assertThrows(BitwardenConnectionException.class, () -> BitwardenCLI.unlock(masterPasswordCredentialsMock));
@@ -383,10 +419,10 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw BitwardenAuthenticationException for invalid master password")
-        void shouldThrowAuthenticationException() throws InterruptedException {
+        void shouldThrowAuthenticationException() {
             // GIVEN
             String errorOutput = "Invalid master password";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             assertThrows(
@@ -396,10 +432,10 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw generic IOException for other errors")
-        void shouldThrowGenericIOException() throws InterruptedException {
+        void shouldThrowGenericIOException() {
             // GIVEN
             String errorOutput = "An unexpected error occurred.";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             IOException exception =
@@ -433,18 +469,17 @@ class BitwardenCLITest {
             BitwardenCLI.sync(mockSessionToken);
 
             // THEN
-            assertEquals(expectedCommand("sync"), capturedCommand);
-            verify(environmentMapMock).put("BW_SESSION", "test-session-token");
-            verify(processBuilderMock).start();
+            assertEquals(expectedCommand("sync"), capturedCommand.toList());
+            assertEquals("test-session-token", capturedEnvs.get("BW_SESSION"));
             verifyExecuteCommandInternals();
         }
 
         @Test
         @DisplayName("should throw BitwardenConnectionException on FetchError")
-        void shouldThrowConnectionException() throws InterruptedException {
+        void shouldThrowConnectionException() {
             // GIVEN
             String errorOutput = "FetchError: request to https://... failed";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             assertThrows(BitwardenConnectionException.class, () -> BitwardenCLI.sync(mockSessionToken));
@@ -453,10 +488,10 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw generic IOException for other errors")
-        void shouldThrowGenericIOException() throws InterruptedException {
+        void shouldThrowGenericIOException() {
             // GIVEN
             String errorOutput = "An unexpected error occurred.";
-            setupMockProcess(errorOutput, 1);
+            setupMockProcess("", errorOutput, 1);
 
             // WHEN & THEN
             IOException exception = assertThrows(IOException.class, () -> BitwardenCLI.sync(mockSessionToken));
@@ -490,9 +525,8 @@ class BitwardenCLITest {
             BitwardenStatus status = BitwardenCLI.status(mockSessionToken);
 
             // THEN
-            assertEquals(expectedCommand("status"), capturedCommand);
-            verify(environmentMapMock).put("BW_SESSION", "test-session-token");
-            verify(processBuilderMock).start();
+            assertEquals(expectedCommand("status"), capturedCommand.toList());
+            assertEquals("test-session-token", capturedEnvs.get("BW_SESSION"));
             assertNotNull(status);
             assertEquals("unlocked", status.getStatus());
             verifyExecuteCommandInternals();
@@ -500,7 +534,7 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw IOException on bad JSON")
-        void shouldThrowIOExceptionOnBadJson() throws InterruptedException {
+        void shouldThrowIOExceptionOnBadJson() {
             // GIVEN
             String badJsonOutput = "this is not json";
             setupMockProcess(badJsonOutput, 0);
@@ -538,9 +572,38 @@ class BitwardenCLITest {
             List<BitwardenItemMetadata> metadataList = BitwardenCLI.listItemsMetadata(mockSessionToken);
 
             // THEN
-            assertEquals(expectedCommand("list", "items"), capturedCommand);
-            verify(environmentMapMock).put("BW_SESSION", "test-session-token");
-            verify(processBuilderMock).start();
+            assertEquals(expectedCommand("list", "items"), capturedCommand.toList());
+            assertEquals("test-session-token", capturedEnvs.get("BW_SESSION"));
+            assertNotNull(metadataList);
+            assertEquals(2, metadataList.size());
+            assertEquals("uuid-1", metadataList.get(0).getId());
+            assertEquals("Item 2", metadataList.get(1).getName());
+            verifyExecuteCommandInternals();
+        }
+
+        @Test
+        @DisplayName("should parse JSON correctly even when stderr has decryption errors")
+        void shouldParseJsonWhenStderrHasDecryptionErrors() throws IOException, InterruptedException {
+            // GIVEN: stderr has decryption errors (real-world scenario from GitHub issue #21)
+            // The bw CLI can emit errors about corrupt attachments on stderr while still
+            // returning valid JSON on stdout with exit code 0.
+            String stderrOutput = """
+                    ERROR bitwarden_crypto::enc_string::symmetric: error=The decryption operation failed
+                    Failed to decrypt property 'fileName' of domain. Context: DomainType: Attachment; Cipher Id: c1345f88-64e0-4f9f-a10b-b1e3004ff4f4.
+                    [Attachment] Error decrypting attachment Error [CryptoError]: The decryption operation failed
+                    Event post failed.""";
+            String jsonOutput = """
+                    [
+                        {"id": "uuid-1", "name": "Item 1", "type": 1},
+                        {"id": "uuid-2", "name": "Item 2", "type": 2}
+                    ]
+                    """;
+            setupMockProcess(jsonOutput, stderrOutput, 0);
+
+            // WHEN
+            List<BitwardenItemMetadata> metadataList = BitwardenCLI.listItemsMetadata(mockSessionToken);
+
+            // THEN — stderr noise must not pollute JSON parsing
             assertNotNull(metadataList);
             assertEquals(2, metadataList.size());
             assertEquals("uuid-1", metadataList.get(0).getId());
@@ -550,7 +613,7 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw IOException on bad JSON")
-        void shouldThrowIOExceptionOnBadJson() throws InterruptedException {
+        void shouldThrowIOExceptionOnBadJson() {
             // GIVEN
             String badJsonOutput = "not a json array";
             setupMockProcess(badJsonOutput, 0);
@@ -590,9 +653,8 @@ class BitwardenCLITest {
             BitwardenItem item = BitwardenCLI.getItem(mockSessionToken, ITEM_ID);
 
             // THEN
-            assertEquals(expectedCommand("get", "item", ITEM_ID), capturedCommand);
-            verify(environmentMapMock).put("BW_SESSION", "test-session-token");
-            verify(processBuilderMock).start();
+            assertEquals(expectedCommand("get", "item", ITEM_ID), capturedCommand.toList());
+            assertEquals("test-session-token", capturedEnvs.get("BW_SESSION"));
             assertNotNull(item);
             assertEquals("My Login", item.getName());
             assertNotNull(item.getLogin());
@@ -602,7 +664,7 @@ class BitwardenCLITest {
 
         @Test
         @DisplayName("should throw IOException on bad JSON")
-        void shouldThrowIOExceptionOnBadJson() throws InterruptedException {
+        void shouldThrowIOExceptionOnBadJson() {
             // GIVEN
             String badJsonOutput = "not a json object";
             setupMockProcess(badJsonOutput, 0);
@@ -627,17 +689,16 @@ class BitwardenCLITest {
             BitwardenCLI.configServer(serverUrl);
 
             // THEN
-            assertEquals(expectedCommand("config", "server", serverUrl), capturedCommand);
-            verify(processBuilderMock).start();
+            assertEquals(expectedCommand("config", "server", serverUrl), capturedCommand.toList());
             verifyExecuteCommandInternals();
         }
 
         @Test
         @DisplayName("should throw IOException on failure")
-        void shouldThrowIOExceptionOnFailure() throws InterruptedException {
+        void shouldThrowIOExceptionOnFailure() {
             // GIVEN
             String serverUrl = "https://vault.example.com";
-            setupMockProcess("Invalid URL.", 1);
+            setupMockProcess("", "Invalid URL.", 1);
 
             // WHEN & THEN
             assertThrows(IOException.class, () -> BitwardenCLI.configServer(serverUrl));

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
@@ -273,15 +273,17 @@ class BitwardenCLITest {
         }
 
         @Test
-        @DisplayName("should kill process and throw IOException on timeout")
+        @DisplayName("should kill process and throw IOException on timeout with stderr visibility")
         void shouldKillProcessAndThrowOnTimeout() throws IOException, InterruptedException {
             // GIVEN: the process is still alive after joinWithTimeout returns
-            setupMockProcess("", 0);
+            String timeoutStderr = "Still waiting for sync...";
+            setupMockProcess("", timeoutStderr, 0);
             when(procMock.isAlive()).thenReturn(true);
 
             // WHEN & THEN
             IOException exception = assertThrows(IOException.class, BitwardenCLI::version);
             assertTrue(exception.getMessage().contains("timed out"));
+            assertTrue(exception.getMessage().contains(timeoutStderr));
             verify(procMock).kill();
             verifyExecuteCommandInternals();
         }

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenCLITest.java
@@ -65,6 +65,7 @@ class BitwardenCLITest {
     // Mocks for Launcher infrastructure
     private MockedConstruction<Launcher.LocalLauncher> launcherMockedConstruction;
     private Launcher.ProcStarter procStarterMock;
+    private Proc procMock;
 
     // Mock instances
     @Mock
@@ -147,7 +148,7 @@ class BitwardenCLITest {
             capturedStderr = invocation.getArgument(0);
             return procStarterMock;
         });
-        Proc procMock = mock(Proc.class);
+        procMock = mock(Proc.class);
         when(procStarterMock.start()).thenReturn(procMock);
         when(procMock.joinWithTimeout(anyLong(), any(TimeUnit.class), any(TaskListener.class)))
                 .thenAnswer(invocation -> {
@@ -268,6 +269,20 @@ class BitwardenCLITest {
             IOException exception = assertThrows(IOException.class, BitwardenCLI::version);
             assertTrue(exception.getMessage().contains("Command failed with exit code 1"));
             assertTrue(exception.getMessage().contains(errorOutput));
+            verifyExecuteCommandInternals();
+        }
+
+        @Test
+        @DisplayName("should kill process and throw IOException on timeout")
+        void shouldKillProcessAndThrowOnTimeout() throws IOException, InterruptedException {
+            // GIVEN: the process is still alive after joinWithTimeout returns
+            setupMockProcess("", 0);
+            when(procMock.isAlive()).thenReturn(true);
+
+            // WHEN & THEN
+            IOException exception = assertThrows(IOException.class, BitwardenCLI::version);
+            assertTrue(exception.getMessage().contains("timed out"));
+            verify(procMock).kill();
             verifyExecuteCommandInternals();
         }
     }

--- a/src/test/java/com/mwdle/bitwarden/cli/BitwardenSessionManagerTest.java
+++ b/src/test/java/com/mwdle/bitwarden/cli/BitwardenSessionManagerTest.java
@@ -262,6 +262,60 @@ class BitwardenSessionManagerTest {
         when(jenkinsMock.getExtensionList(CredentialsProvider.class)).thenReturn(extensionList);
     }
 
+    @Nested
+    @DisplayName("isSessionValid() method")
+    class IsSessionValid {
+        @Test
+        @DisplayName("should return true if token is present and vault is unlocked")
+        void shouldReturnTrueWhenUnlocked() throws Exception {
+            // GIVEN
+            Secret token = Secret.fromString("some-token");
+            sessionTokenField.set(manager, token);
+
+            BitwardenStatus unlockedStatus = mock(BitwardenStatus.class);
+            when(unlockedStatus.getStatus()).thenReturn("unlocked");
+            mockedCli.when(() -> BitwardenCLI.status(token)).thenReturn(unlockedStatus);
+
+            // WHEN
+            boolean result = manager.isSessionValid();
+
+            // THEN
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("should handle InterruptedException and restore interrupt flag")
+        void shouldHandleInterruptedException() throws Exception {
+            // GIVEN
+            Secret token = Secret.fromString("some-token");
+            sessionTokenField.set(manager, token);
+
+            mockedCli.when(() -> BitwardenCLI.status(token)).thenThrow(new InterruptedException("Interrupted!"));
+
+            // Ensure the thread is NOT interrupted before the test
+            Thread.interrupted();
+
+            // WHEN
+            boolean result = manager.isSessionValid();
+
+            // THEN
+            assertFalse(result, "isSessionValid should return false when interrupted");
+            assertTrue(Thread.interrupted(), "Thread interrupt flag should be set");
+        }
+
+        @Test
+        @DisplayName("should return false if token is null")
+        void shouldReturnFalseWhenTokenIsNull() {
+            // GIVEN: manager starts with null sessionToken
+
+            // WHEN
+            boolean result = manager.isSessionValid();
+
+            // THEN
+            assertFalse(result);
+        }
+    }
+
     private void setupValidCredentials(String serverUrl) {
         StandardUsernamePasswordCredentials apiKey = mock(StandardUsernamePasswordCredentials.class);
         when(apiKey.getId()).thenReturn("api-key-id");


### PR DESCRIPTION
- Safely splits Bitwarden CLI `stdout` and `stderr` using Jenkins' built-in `Launcher` APIs to execute the CLI.
- Ensures non-fatal `stderr` output no longer breaks JSON parsing, while still logging those warnings safely at the `FINE` level.
- Introduces a strict 5-minute CLI execution timeout to prevent unexpected delays from hanging Jenkins threads indefinitely.
- Properly handles `InterruptedException` in `BitwardenSessionManager` and restores interrupt flag
- Implements tests to validate new functionality.

Fixes #21

### Testing done

Tested all features via `mvn hpi:run` and Jenkins UI. Updated and created automated tests to validate new and existing functionality.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed